### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ Creates a field with provided `id`.
   - `Array` (requires `items`)
   - `Link` (requires `linkType`)
   - `ResourceLink` (requires `allowedResources`)
-- **`items : Object`** _(required for type 'Array')_ – Defines the items of an Array field.
+- **`items : Object`** _(required for type `Array`)_ – Defines the items of an Array field.
   Example:
 
   ```javascript
@@ -554,9 +554,9 @@ Creates a field with provided `id`.
   }
   ```
 
-- **`linkType : string`** _(required for type 'Link')_ – Type of the referenced entry.
-  Can take the same values as the ones listed for `type` above.
-- **`allowedResources`** _(required for type 'ResourceLink')_ - Defines which resources can be linked through the field.
+- **`linkType : string`** _(required for type `Link`)_ – Type of the referenced entry.
+  Value must be either `Asset` or `Entry`.
+- **`allowedResources`** _(required for type `ResourceLink`)_ - Defines which resources can be linked through the field.
 - **`required : boolean`** – Sets the field as required.
 - **`validations : Array`** – Validations for the field.
   Example:


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

* Fixed values for `linkType`
* Wrapped referenced types in backticks

## Description

<!-- Describe your changes in detail -->

In my experience with Contentful migration scripts, `linkType` does not share values with `Type` as the documentation states, but rather takes in a `string` value of either `"Asset"` or `"Entry"`.

I have wrapped referenced types in backticks to be consistent with how they are referenced earlier in the documentation.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

I am using Contentful and was reading through the documentation when I found these typos and changes.